### PR TITLE
Use odbc_fdw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,15 @@ RUN apt-get install -y libmysqlclient-dev
 RUN apt-get install -y wget
 RUN apt-get install -y net-tools
 
+# Install ODBC drivers
+RUN apt-get install -y unixodbc-dev
+# SQL Server
+RUN apt-get install -y tdsodbc
+# Postgres
+RUN apt-get install odbc-postgresql
+# MySQL
+RUN apt-get install odbc-libmyodbc
+
 # Note: The official Debian and Ubuntu images automatically ``apt-get clean``
 # after each ``apt-get``
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,22 @@ RUN apt-get install -y libmysqlclient-dev
 RUN apt-get install -y wget
 RUN apt-get install -y net-tools
 
-# Install ODBC drivers
-RUN apt-get install -y unixodbc-dev
+# Download ODBC drivers
+RUN apt-get install -y unixodbc unixodbc-dev
 # SQL Server
 RUN apt-get install -y tdsodbc
 # Postgres
 RUN apt-get install odbc-postgresql
 # MySQL
-RUN apt-get install odbc-libmyodbc
+RUN  wget -c https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar.gz &&\
+    gunzip mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar.gz &&\
+    tar -xf  mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar.gz -C /usr/lib/mysql-connector-odbc/
+
+# Install the drivers
+# MySQL
+RUN /usr/lib/mysql-connector-odbc/bin/myodbc-installer -d -a -n "MySQL" -t "DRIVER=/usr/lib/mysql-connector-odbc/bin/lib/libmyodbc5w.so"
+# Postgres
+RUN /usr/lib/mysql-connector-odbc/bin/myodbc-installer -d -a -n "PostgreSQL" -t "DRIVER=/usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so"
 
 # Note: The official Debian and Ubuntu images automatically ``apt-get clean``
 # after each ``apt-get``

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN  wget -c https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connec
 RUN /usr/lib/mysql-connector-odbc/bin/myodbc-installer -d -a -n "MySQL" -t "DRIVER=/usr/lib/mysql-connector-odbc/bin/lib/libmyodbc5w.so"
 # Postgres
 RUN /usr/lib/mysql-connector-odbc/bin/myodbc-installer -d -a -n "PostgreSQL" -t "DRIVER=/usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so"
+# SQL Server
+RUN /usr/lib/mysql-connector-odbc/bin/myodbc-installer -d -a -n "SQL Server" -t "DRIVER=/usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so"
 
 # Note: The official Debian and Ubuntu images automatically ``apt-get clean``
 # after each ``apt-get``

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ USER postgres
 RUN    /etc/init.d/postgresql start &&\
     psql --command "CREATE USER docker WITH SUPERUSER PASSWORD 'docker';" &&\
     createdb -O docker joiner &&\
-    psql -d joiner --command "CREATE EXTENSION postgres_fdw; CREATE EXTENSION mysql_fdw;"
+    psql -d joiner --command "CREATE EXTENSION odbc_fdw"
 
 # Adjust PostgreSQL configuration so that remote connections to the
 # database are possible.

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,16 @@ RUN apt-get install -y tdsodbc
 # Postgres
 RUN apt-get install odbc-postgresql
 # MySQL
-RUN  wget -c https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar.gz &&\
-    gunzip mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar.gz &&\
-    tar -xf  mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar.gz -C /usr/lib/mysql-connector-odbc/
+RUN mkdir /usr/lib/mysql-connector-odbc/
+RUN  wget -c https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar.gz
+RUN gunzip mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar.gz
+RUN tar -xf  mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar -C /usr/lib/mysql-connector-odbc/
 
 # Install the drivers
 # MySQL
-RUN /usr/lib/mysql-connector-odbc/bin/myodbc-installer -d -a -n "MySQL" -t "DRIVER=/usr/lib/mysql-connector-odbc/bin/lib/libmyodbc5w.so"
+RUN /usr/lib/mysql-connector-odbc/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit/bin/myodbc-installer -d -a -n "MySQL" -t "DRIVER=/usr/lib/mysql-connector-odbc/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit/lib/libmyodbc5w.so"
 # Postgres
-RUN /usr/lib/mysql-connector-odbc/bin/myodbc-installer -d -a -n "PostgreSQL" -t "DRIVER=/usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so"
+RUN /usr/lib/mysql-connector-odbc/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit/bin/myodbc-installer -d -a -n "PostgreSQL" -t "DRIVER=/usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so"
 
 # Note: The official Debian and Ubuntu images automatically ``apt-get clean``
 # after each ``apt-get``

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,14 @@ RUN /usr/lib/mysql-connector-odbc/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x
 # Note: The official Debian and Ubuntu images automatically ``apt-get clean``
 # after each ``apt-get``
 
+# Add the odbc_fdw
+RUN git clone https://github.com/CartoDB/odbc_fdw.git
+RUN cd odbc_fdw &&\
+    sed -i "s/create_foreignscan_path(root, baserel, baserel->rows/create_foreignscan_path(root, baserel, NULL, baserel->rows/g" odbc_fdw.c &&\
+    make &&\
+    make install
+RUN cd ..
+
 # Add the mysql_fdw
 RUN export PATH=/usr/lib/postgresql/9.6/bin/:$PATH
 RUN export PATH=/usr/lib/mysql-client/bin/:$PATH

--- a/joindb_api.rb
+++ b/joindb_api.rb
@@ -72,8 +72,8 @@ def add_fdw_postgres(username, password, remoteuser, remotepass, remotehost, rem
     end
 end
 
-# Adds a MySQL FDW
-def add_fdw_mysql(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteport=3306)
+# Adds a MySQL FDW or a SQL Server FDW depending on whether drivertype is "MySQL" or "SQL Server"
+def add_fdw_other(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteport=3306, driver_type)
     remotehost = dockerize_localhost(remotehost)
     conn = open_connection(DB_NAME, username, password)
     schema_name = "#{remotedbname}"
@@ -83,7 +83,7 @@ def add_fdw_mysql(username, password, remoteuser, remotepass, remotehost, remote
             conn.exec("CREATE SERVER #{schema_name}
                 FOREIGN DATA WRAPPER odbc_fdw
                 OPTIONS (
-                    odbc_DRIVER 'MySQL',
+                    odbc_DRIVER '#{driver_type}',
                     odbc_SERVER '#{remotehost}', 
                     odbc_PORT '#{remoteport}'
                 )")

--- a/joindb_api.rb
+++ b/joindb_api.rb
@@ -35,28 +35,37 @@ def dockerize_localhost(remotehost)
 end
 
 # Adds a Postgres FDW
-def add_fdw_postgres(fdw_type, username, password, remoteuser, remotepass, remotehost, remotedbname, remoteschema, remoteport=5432)
+def add_fdw_postgres(username, password='', remoteuser, remotepass, remotehost, remotedbname, remoteschema, remoteport=5432)
     remotehost = dockerize_localhost(remotehost)
     conn = open_connection(DB_NAME, username, password)    
     schema_name = "#{remotedbname}_#{remoteschema}"
     begin
-        conn.transaction do |conn|
-            conn.send_query("CREATE EXTENSION IF NOT EXISTS #{fdw_type}") 
-        end
-
         conn.transaction do |c| 
+            # Create the server
             c.exec("CREATE SERVER #{schema_name}
                 FOREIGN DATA WRAPPER #{fdw_type}
-                OPTIONS (host '#{remotehost}', dbname '#{remotedbname}', port '#{remoteport}')")
+                OPTIONS (
+                    odbc_DRIVER 'PostgreSQL',
+                    odbc_SERVERNAME '#{remotehost}',
+                    odbc_PORT '#{remoteport}'
+                )")
+            
+            # Create the user mapping
             c.exec("CREATE USER MAPPING FOR #{username}
                 SERVER #{schema_name}
-                OPTIONS (user '#{remoteuser}', password '#{remotepass}')")
+                OPTIONS (
+                    odbc_USERNAME '#{remoteuser}',
+                    odbc_PASSWORD '#{remotepass}'
+                )")
             
             # Import the schema
             c.exec("CREATE SCHEMA #{schema_name}")
             c.exec("IMPORT FOREIGN SCHEMA #{remoteschema}
                 FROM SERVER #{schema_name}
-                INTO #{schema_name}")
+                INTO #{schema_name}
+                OPTIONS (
+                    odbc_DATABASE '#{remotedbname}'
+                )")
         end
     rescue StandardError
         $stderr.print "Error: #{$!}"
@@ -64,28 +73,36 @@ def add_fdw_postgres(fdw_type, username, password, remoteuser, remotepass, remot
 end
 
 # Adds a MySQL FDW
-def add_fdw_mysql(fdw_type, username, password, remoteuser, remotepass, remotehost, remotedbname, remoteport=3306)
+def add_fdw_mysql(username, password='', remoteuser, remotepass, remotehost, remotedbname, remoteport=3306)
     remotehost = dockerize_localhost(remotehost)
     conn = open_connection(DB_NAME, username, password)
     schema_name = "#{remotedbname}"
     begin
         conn.transaction do |conn| 
-            conn.exec("CREATE EXTENSION IF NOT EXISTS #{fdw_type}")
-            conn.get_result
-        end
-
-        conn.transaction do |conn| 
+            # Create the server
             conn.exec("CREATE SERVER #{schema_name}
                 FOREIGN DATA WRAPPER #{fdw_type}
-                OPTIONS (host '#{remotehost}', port '#{remoteport}')")
+                OPTIONS (
+                    odbc_SERVER '#{remotehost}', 
+                    pdbc_PORT '#{remoteport}'
+                )")
+            
+            # Create the user mapping
             conn.exec("CREATE USER MAPPING FOR #{username}
                 SERVER #{schema_name}
-                OPTIONS (username '#{remoteuser}', password '#{remotepass}')")
+                OPTIONS (
+                    odbc_UID '#{remoteuser}',
+                    odbc_PWD '#{remotepass}'
+                )")
+            
             # Import the schema
             conn.exec("CREATE SCHEMA #{schema_name}")
             conn.exec("IMPORT FOREIGN SCHEMA #{schema_name}
                 FROM SERVER #{schema_name}
-                INTO #{schema_name}")
+                INTO #{schema_name}
+                OPTIONS (
+                    odbc_DATABASE '#{schema_name}'
+                )")
         end
     rescue StandardError
         $stderr.print "Error: #{$!}"

--- a/joindb_api.rb
+++ b/joindb_api.rb
@@ -35,7 +35,7 @@ def dockerize_localhost(remotehost)
 end
 
 # Adds a Postgres FDW
-def add_fdw_postgres(username, password='', remoteuser, remotepass, remotehost, remotedbname, remoteschema, remoteport=5432)
+def add_fdw_postgres(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteschema, remoteport=5432)
     remotehost = dockerize_localhost(remotehost)
     conn = open_connection(DB_NAME, username, password)    
     schema_name = "#{remotedbname}_#{remoteschema}"
@@ -43,7 +43,7 @@ def add_fdw_postgres(username, password='', remoteuser, remotepass, remotehost, 
         conn.transaction do |c| 
             # Create the server
             c.exec("CREATE SERVER #{schema_name}
-                FOREIGN DATA WRAPPER #{fdw_type}
+                FOREIGN DATA WRAPPER odbc_fdw
                 OPTIONS (
                     odbc_DRIVER 'PostgreSQL',
                     odbc_SERVERNAME '#{remotehost}',
@@ -73,7 +73,7 @@ def add_fdw_postgres(username, password='', remoteuser, remotepass, remotehost, 
 end
 
 # Adds a MySQL FDW
-def add_fdw_mysql(username, password='', remoteuser, remotepass, remotehost, remotedbname, remoteport=3306)
+def add_fdw_mysql(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteport=3306)
     remotehost = dockerize_localhost(remotehost)
     conn = open_connection(DB_NAME, username, password)
     schema_name = "#{remotedbname}"
@@ -81,10 +81,11 @@ def add_fdw_mysql(username, password='', remoteuser, remotepass, remotehost, rem
         conn.transaction do |conn| 
             # Create the server
             conn.exec("CREATE SERVER #{schema_name}
-                FOREIGN DATA WRAPPER #{fdw_type}
+                FOREIGN DATA WRAPPER odbc_fdw
                 OPTIONS (
+                    odbc_DRIVER 'MySQL',
                     odbc_SERVER '#{remotehost}', 
-                    pdbc_PORT '#{remoteport}'
+                    odbc_PORT '#{remoteport}'
                 )")
             
             # Create the user mapping

--- a/joindb_client_methods.rb
+++ b/joindb_client_methods.rb
@@ -63,7 +63,7 @@ def add_db_prompt(username, password)
     print "Username: "
     remoteuser = gets.chomp
     print "Password: "
-    remotepass = STDIN.noecho(&:gets).chomp
+    remotepass = STDIN.noecho(&:gets).chomp || ""
     puts
     print "Host: "
     remotehost = gets.chomp

--- a/joindb_client_methods.rb
+++ b/joindb_client_methods.rb
@@ -80,9 +80,9 @@ def add_db_prompt(username, password)
     # Add it
     case fdw_type
     when DB_FDW_MAPPING[:Postgres]
-        add_fdw_postgres(fdw_type, username, password, remoteuser, remotepass, remotehost, remotedbname, remoteschema, remoteport)
+        add_fdw_postgres(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteschema, remoteport)
     when DB_FDW_MAPPING[:MySQL]
-        add_fdw_mysql(fdw_type, username, password, remoteuser, remotepass, remotehost, remotedbname, remoteport)
+        add_fdw_mysql(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteport)
     end
 end
 

--- a/joindb_client_methods.rb
+++ b/joindb_client_methods.rb
@@ -3,7 +3,8 @@ require 'io/console'
 
 DB_FDW_MAPPING = {
     :Postgres => "postgres_fdw",
-    :MySQL => "mysql_fdw"
+    :MySQL => "mysql_fdw",
+    :SQLServer => "sql_server_fdw"
 }
 
 # Gets the user's username and password for the Analytics DB
@@ -82,7 +83,9 @@ def add_db_prompt(username, password)
     when DB_FDW_MAPPING[:Postgres]
         add_fdw_postgres(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteschema, remoteport)
     when DB_FDW_MAPPING[:MySQL]
-        add_fdw_mysql(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteport)
+        add_fdw_other(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteport, "MySQL")
+    when DB_FDW_MAPPING[:SQLServer]
+        add_fdw_other(username, password, remoteuser, remotepass, remotehost, remotedbname, remoteport, "SQL Server")
     end
 end
 


### PR DESCRIPTION
As a solution to issue #3, I refactored the Dockerfile and client to use `odbc_fdw` instead of maintaining multiple FDWs for Postgres, MySQL, and SQL Server.

Benefits are:
1. `mysql_fdw` was really slow
2. Easy support for SQL Server
3. This is more extensible, i.e. we can add other DB types easily